### PR TITLE
[#86] Anadido volumen al contenedor de app para copiar las credencial…

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,12 @@
+APP_NAME=Lumen
+APP_ENV=local
+APP_KEY=
+APP_DEBUG=true
+APP_URL=http://localhost
+
+DB_CONNECTION=mysql
+DB_HOST=db
+DB_PORT=3306
+DB_DATABASE=lumen
+DB_USERNAME=lumen
+DB_PASSWORD=secret

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -9,6 +9,7 @@ services:
       - "8080:80"
     volumes:
       - .:/var/www/html
+      - ~/.gitconfig:/root/.gitconfig:ro
     env_file:
       - .env
     networks:


### PR DESCRIPTION
…es de git al montarse

Ahora al montarse el contenedor de la aplicación copia automáticamente las credenciales de nombre de usuario y correo electrónico, aunque sigue haciendo falta meter la contraseña o el token dentro del contenedor.

También he metido un .env.example sin información crítica por que me está borrando constantemente mi .env local al hacer checkouts y pulls.