### PR TITLE
[#] - Arreglado error en register. Faltaba pasar un parametro en una …

### DIFF
--- a/src/Service/Register.php
+++ b/src/Service/Register.php
@@ -45,7 +45,7 @@ class Register
             }
         }
 
-        if (!$this->updateUserKey($hashedNewApiKey, $email)) {
+        if (!$this->updateUserKey($hashedNewApiKey, $email, $con)) {
             return ['data' => ["error" => "Internal server error."], 'http_code' => 500];
         }
         return ['data' => ["api_key" => $newApiKey], 'http_code' => 200];


### PR DESCRIPTION
…funcion (updateUserKey) en line 48

Básicamente en Register.php había una llamada a un método que faltaba un parámetro, y por eso no se ejecutaba register con los cual todos los tests fallaban con error 401. 
Ahora mismo ya corren bien y solo falla enriched que creo que habeis comentado el porqué por wasap